### PR TITLE
fix value extraction in MLAT sort handler

### DIFF
--- a/VirtualRadar.WebSite/Site/Web/script/vrs/aircraftListSorter.js
+++ b/VirtualRadar.WebSite/Site/Web/script/vrs/aircraftListSorter.js
@@ -147,7 +147,7 @@ var VRS;
     VRS.aircraftListSortHandlers[VRS.AircraftListSortableField.Mlat] = new VRS.AircraftListSortHandler({
         field: VRS.AircraftListSortableField.Mlat,
         labelKey: 'Mlat',
-        getNumberCallback: function (aircraft) { return aircraft.isMlat.val === undefined ? 0 : aircraft.isMlat ? 1 : 2; }
+        getNumberCallback: function (aircraft) { return aircraft.isMlat.val === undefined ? 0 : aircraft.isMlat.val ? 1 : 2; }
     });
     VRS.aircraftListSortHandlers[VRS.AircraftListSortableField.Model] = new VRS.AircraftListSortHandler({
         field: VRS.AircraftListSortableField.Model,


### PR DESCRIPTION
Hi,

In VRS 2.4.0, attempting to sort by MLAT in the website arranges the rows incorrectly.   This is because of a bug in the sort handler's `getNumberCallback` -- when a MLAT value _is_ available, the function is checking truthiness of the `isMlat` object, rather than its `val` property.  This PR fixes that.