### PR TITLE
Fixed locale specific issues and Build.bat fix for VS2022

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -1,10 +1,5 @@
 @echo off
 
-set "VS2017MSB=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
-set "VS2019MSB=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
-
-set                          "MSBUILD=%VS2019MSB%"
-if not exist "%MSBUILD%" set "MSBUILD=%VS2017MSB%"
 set SRC=%~dp0
 set "SOLUTION=%SRC%VirtualRadar.sln"
 set NOWARN=1570,1572,1573,1574,1584,1587,1591,1711
@@ -20,8 +15,6 @@ set X64=0
     if "%1"=="-debug"   set DEBUG=1
     if "%1"=="-x86"     set X86=1
     if "%1"=="-x64"     set X64=1
-    if "%1"=="-vs2017"  set "MSBUILD=%VS2017MSB%"
-    if "%1"=="-vs2019"  set "MSBUILD=%VS2019MSB%"
     shift
     goto :NEXTARG
 :ENDARGS
@@ -43,7 +36,7 @@ for %%C IN (%CONFIGS%) do (
     for %%P IN (%PLATFORMS%) do (
         set PLATFORM=%%P
 
-        "%MSBUILD%" "%SOLUTION%" -target:Restore,Build -property:Configuration=%%C,Platform=%%P -nowarn:%NOWARN%
+        msbuild "%SOLUTION%" -target:Restore,Build -property:Configuration=%%C,Platform=%%P -nowarn:%NOWARN%
         if ERRORLEVEL 1 goto :FAILED
     )
 )
@@ -61,7 +54,6 @@ goto :EOF
     echo Compilation failed - build is incomplete
     echo Configuration: %CONFIG%
     echo Platform:      %PLATFORM%
-    echo MSBuild:       %MSBUILD%
     echo.
     echo Build failed
     exit /b 1

--- a/Plugin.BaseStationDatabaseWriter/OnlineLookupCache.cs
+++ b/Plugin.BaseStationDatabaseWriter/OnlineLookupCache.cs
@@ -219,7 +219,7 @@ namespace VirtualRadar.Plugin.BaseStationDatabaseWriter
             var database = Database;
             if(database != null && Enabled) {
                 var map = new Dictionary<string, AircraftOnlineLookupDetail>();
-                string normaliseIcao(string icao) => icao.ToUpper();
+                string normaliseIcao(string icao) => icao.ToUpperInvariant();
 
                 foreach(var lookupDetail in lookupDetails) {
                     var icao = normaliseIcao(lookupDetail.Icao);

--- a/Plugin.CustomContent/Plugin.cs
+++ b/Plugin.CustomContent/Plugin.cs
@@ -293,7 +293,7 @@ namespace VirtualRadar.Plugin.CustomContent
                     foreach(var injectSettings in options.InjectSettings.Where(r => r.Enabled)) {
                         var injector = new CustomHtmlContentInjector() {
                             AtStart = injectSettings.Start,
-                            Element = injectSettings.InjectionLocation.ToString().ToLower(),
+                            Element = injectSettings.InjectionLocation.ToString().ToLowerInvariant(),
                             FileName = injectSettings.File,
                             PathAndFile = injectSettings.PathAndFile == "*" ? null : injectSettings.PathAndFile,
                             Priority = priority++,

--- a/Plugin.CustomContent/WinForms/OptionsView.cs
+++ b/Plugin.CustomContent/WinForms/OptionsView.cs
@@ -189,7 +189,7 @@ namespace VirtualRadar.Plugin.CustomContent.WinForms
             FillListViewItem<InjectSettings>(item, r => new String[] {
                 r.Enabled ? Strings.Yes : Strings.No,
                 r.File,
-                r.InjectionLocation.ToString().ToUpper(),
+                r.InjectionLocation.ToString().ToUpperInvariant(),
                 r.Start ? CustomContentStrings.Start : CustomContentStrings.End,
                 r.PathAndFile,
             });

--- a/Plugin.DatabaseEditor/ApiControllers/DatabaseEditorController.cs
+++ b/Plugin.DatabaseEditor/ApiControllers/DatabaseEditorController.cs
@@ -23,7 +23,7 @@ namespace VirtualRadar.Plugin.DatabaseEditor.ApiControllers
                     result.Aircraft = plugin.BaseStationDatabase.GetAircraftByCode(icao);
                     if(result.Aircraft == null) {
                         result.Aircraft = new BaseStationAircraft();
-                        result.Aircraft.ModeS = icao.ToUpper();
+                        result.Aircraft.ModeS = icao.ToUpperInvariant();
                     }
                     plugin.IncrementSearchCount();
                     plugin.UpdateStatusTotals();
@@ -47,9 +47,9 @@ namespace VirtualRadar.Plugin.DatabaseEditor.ApiControllers
                 result.Aircraft = aircraft;
 
                 if(CustomConvert.Icao24(aircraft?.ModeS) > 0) {
-                    aircraft.Registration =     aircraft?.Registration?.ToUpper().Trim();
-                    aircraft.ICAOTypeCode =     aircraft?.ICAOTypeCode?.ToUpper().Trim();
-                    aircraft.OperatorFlagCode = aircraft?.OperatorFlagCode?.ToUpper().Trim();
+                    aircraft.Registration =     aircraft?.Registration?.ToUpperInvariant().Trim();
+                    aircraft.ICAOTypeCode =     aircraft?.ICAOTypeCode?.ToUpperInvariant().Trim();
+                    aircraft.OperatorFlagCode = aircraft?.OperatorFlagCode?.ToUpperInvariant().Trim();
                     aircraft.LastModified = DateTime.Now;
 
                     if(aircraft.UserString1 == "Missing") {

--- a/Plugin.DatabaseEditor/Plugin.cs
+++ b/Plugin.DatabaseEditor/Plugin.cs
@@ -315,8 +315,7 @@ namespace VirtualRadar.Plugin.DatabaseEditor
         /// <param name="e"></param>
         void WebSite_HtmlLoadedFromFile(object sender, TextContentEventArgs e)
         {
-            var key = e.PathAndFile.ToLower();
-            if(key.StartsWith("/databaseeditor/")) {
+            if(e.PathAndFile.StartsWith("/databaseeditor/", StringComparison.InvariantCultureIgnoreCase)) {
                 e.Content = _HtmlLocaliser.Html(e.Content, e.Encoding);
             }
         }

--- a/Plugin.FeedFilter/Json/FilterConfigurationJson.cs
+++ b/Plugin.FeedFilter/Json/FilterConfigurationJson.cs
@@ -93,7 +93,7 @@ namespace VirtualRadar.Plugin.FeedFilter.Json
 
             if(!String.IsNullOrEmpty(rawIcaos)) {
                 foreach(var chunk in rawIcaos.Split(new char[] { ';', ',', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
-                    var candidate = chunk.ToUpper().Trim();
+                    var candidate = chunk.ToUpperInvariant().Trim();
                     var rangeSeparatorIndex = candidate.IndexOf('-');
                     if(rangeSeparatorIndex == -1) {
                         ParseSingleIcao(candidate, singleIcaos, duplicateIcaos, invalidIcaos);

--- a/Plugin.FeedFilter/Plugin.cs
+++ b/Plugin.FeedFilter/Plugin.cs
@@ -345,8 +345,7 @@ namespace VirtualRadar.Plugin.FeedFilter
         /// <param name="e"></param>
         void WebSite_HtmlLoadedFromFile(object sender, TextContentEventArgs e)
         {
-            var key = e.PathAndFile.ToLower();
-            if(key.StartsWith("/feedfilter/")) {
+            if(e.PathAndFile.StartsWith("/feedfilter/", StringComparison.InvariantCultureIgnoreCase)) {
                 e.Content = _HtmlLocaliser.Html(e.Content, e.Encoding);
             }
         }

--- a/Plugin.SqlServer/BaseStationDatabase.cs
+++ b/Plugin.SqlServer/BaseStationDatabase.cs
@@ -471,10 +471,10 @@ namespace VirtualRadar.Plugin.SqlServer
 
         private void NormaliseCriteria(SearchBaseStationCriteria criteria)
         {
-            if(criteria?.Callsign != null)      criteria.Callsign.ToUpper();
-            if(criteria?.Icao != null)          criteria.Icao.ToUpper();
-            if(criteria?.Registration != null)  criteria.Registration.ToUpper();
-            if(criteria?.Type != null)          criteria.Type.ToUpper();
+            if(criteria?.Callsign != null)      criteria.Callsign.ToUpperInvariant();
+            if(criteria?.Icao != null)          criteria.Icao.ToUpperInvariant();
+            if(criteria?.Registration != null)  criteria.Registration.ToUpperInvariant();
+            if(criteria?.Type != null)          criteria.Type.ToUpperInvariant();
         }
 
         private int Flights_GetCountByCriteria(ConnectionWrapper wrapper, BaseStationAircraft aircraft, SearchBaseStationCriteria criteria)
@@ -774,7 +774,7 @@ namespace VirtualRadar.Plugin.SqlServer
         {
             return SqlServerHelper.UdttParameter<Icao24Udtt>(
                 Icao24Udtt.UdttProperties,
-                icao24s?.Select(r => (r ?? "").ToUpper().Trim()).Where(r => r != "").Distinct().Select(r => new Icao24Udtt(r))
+                icao24s?.Select(r => (r ?? "").ToUpperInvariant().Trim()).Where(r => r != "").Distinct().Select(r => new Icao24Udtt(r))
             );
         }
 

--- a/Plugin.SqlServer/SqlServerHelper.cs
+++ b/Plugin.SqlServer/SqlServerHelper.cs
@@ -60,7 +60,7 @@ namespace VirtualRadar.Plugin.SqlServer
                 using(var reader = new StringReader(script)) {
                     string line;
                     while((line = reader.ReadLine()) != null) {
-                        if(line.Trim().ToUpper() != "GO") {
+                        if(!line.Trim().Equals("GO", StringComparison.InvariantCultureIgnoreCase)) {
                             scriptLines.Add(line);
                         } else {
                             RunScriptChunk(connection, scriptLines, commandTimeoutSeconds);

--- a/Plugin.TileServerCache/WebRequestHandler.cs
+++ b/Plugin.TileServerCache/WebRequestHandler.cs
@@ -167,7 +167,7 @@ namespace VirtualRadar.Plugin.TileServerCache
                 request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
                 foreach(var headerKey in headers.Keys) {
                     var value = headers[headerKey];
-                    switch(headerKey.ToLower()) {
+                    switch(headerKey.ToLowerInvariant()) {
                         case "accept":              request.Accept = value; break;
                         case "accept-encoding":     break;
                         case "connection":          break;

--- a/Plugin.TileServerCache/WebServerV3Middleware.cs
+++ b/Plugin.TileServerCache/WebServerV3Middleware.cs
@@ -59,7 +59,7 @@ namespace VirtualRadar.Plugin.TileServerCache
                 context.ResponseStatusCode = (int)outcome.StatusCode;
                 if(outcome.ImageBytes != null) {
                     var mimeType = "";
-                    switch((outcome.ImageExtension ?? "").ToLower()) {
+                    switch((outcome.ImageExtension ?? "").ToLowerInvariant()) {
                         case ".bmp":    mimeType = MimeType.BitmapImage; break;
                         case ".gif":    mimeType = MimeType.GifImage; break;
                         case ".jpg":    mimeType = MimeType.JpegImage; break;

--- a/Plugin.WebAdmin/ViewMethodMapper.cs
+++ b/Plugin.WebAdmin/ViewMethodMapper.cs
@@ -533,7 +533,7 @@ namespace VirtualRadar.Plugin.WebAdmin
         /// <returns></returns>
         private string NormaliseString(string text)
         {
-            return (text ?? "").ToLower();
+            return (text ?? "").ToLowerInvariant();
         }
 
         /// <summary>

--- a/Plugin.WebAdmin/WebAdminViewManager.cs
+++ b/Plugin.WebAdmin/WebAdminViewManager.cs
@@ -346,7 +346,7 @@ namespace VirtualRadar.Plugin.WebAdmin
         /// <returns></returns>
         private string NormaliseFullPath(string fullPath, bool appendTrailingSlash = false)
         {
-            var result = String.IsNullOrEmpty(fullPath) ? "" : fullPath.ToLower();
+            var result = String.IsNullOrEmpty(fullPath) ? "" : fullPath.ToLowerInvariant();
             if(appendTrailingSlash && (result.Length == 0 || result[result.Length - 1] != '/')) {
                 result = String.Format("{0}/", result);
             }

--- a/Test/Test.Framework/ExcelWorksheetData.cs
+++ b/Test/Test.Framework/ExcelWorksheetData.cs
@@ -244,7 +244,7 @@ namespace Test.Framework
                 var parsed = new List<int>();
                 var kind = DateTimeKind.Unspecified;
                 for(int i = 0;i < dateParts.Length;++i) {
-                    switch(dateParts[i].ToUpper()) {
+                    switch(dateParts[i].ToUpperInvariant()) {
                         case "L":   kind = DateTimeKind.Local; break;
                         case "Z":
                         case "U":   kind = DateTimeKind.Utc; break;

--- a/Test/Test.VirtualRadar.Database/StandingDataManagerTests.cs
+++ b/Test/Test.VirtualRadar.Database/StandingDataManagerTests.cs
@@ -76,14 +76,14 @@ namespace Test.VirtualRadar.Database
             _FileExists.Add(DatabaseFileName, true);
             _FileExists.Add(FlightNumberCoverageFileName, true);
             _Provider.Setup(p => p.FileExists(It.IsAny<string>())).Returns((string fileName) => {
-                var key = String.IsNullOrEmpty(fileName) ? null : Path.GetFileName(fileName).ToUpper();
+                var key = String.IsNullOrEmpty(fileName) ? null : Path.GetFileName(fileName).ToUpperInvariant();
                 return key != null && _FileExists.ContainsKey(key) ? _FileExists[key] : false;
             });
 
             _ReadAllLines = new Dictionary<string,List<string>>();
             _ReadAllLines.Add(FlightNumberCoverageFileName, new List<string>());
             _Provider.Setup(p => p.ReadAllLines(It.IsAny<string>())).Returns((string fileName) => {
-                return _ReadAllLines[Path.GetFileName(fileName).ToUpper()].ToArray();
+                return _ReadAllLines[Path.GetFileName(fileName).ToUpperInvariant()].ToArray();
             });
 
             _ReadAllLines[FlightNumberCoverageFileName].Add("A,B,C,D,E");
@@ -139,7 +139,7 @@ namespace Test.VirtualRadar.Database
 
         private void CheckFileMissingRouteStatusMessage(string missingFile)
         {
-            missingFile = missingFile.ToUpper();
+            missingFile = missingFile.ToUpperInvariant();
             foreach(var fileName in AllFileNames) {
                 _FileExists[fileName] = fileName != missingFile;
             }

--- a/Test/Test.VirtualRadar.Database/StandingDataUpdaterTests.cs
+++ b/Test/Test.VirtualRadar.Database/StandingDataUpdaterTests.cs
@@ -81,7 +81,7 @@ namespace Test.VirtualRadar.Database
                 _FileExists.Add(fileName, true);
             }
             _Provider.Setup(p => p.FileExists(It.IsAny<string>())).Returns((string fileName) => {
-                return _FileExists[fileName.ToUpper()];
+                return _FileExists[fileName.ToUpperInvariant()];
             });
 
             _ReadLines = new Dictionary<string,List<string>>();
@@ -89,7 +89,7 @@ namespace Test.VirtualRadar.Database
                 _ReadLines.Add(fileName, new List<string>());
             }
             _Provider.Setup(p => p.ReadLines(It.IsAny<string>())).Returns((string fileName) => {
-                return _ReadLines[fileName.ToUpper()].ToArray();
+                return _ReadLines[fileName.ToUpperInvariant()].ToArray();
             });
 
             _DownloadLines = new Dictionary<string,List<string>>();
@@ -97,24 +97,24 @@ namespace Test.VirtualRadar.Database
                 _DownloadLines.Add(url, new List<string>());
             }
             _Provider.Setup(p => p.DownloadLines(It.IsAny<string>())).Returns((string url) => {
-                return _DownloadLines[url.ToUpper()].ToArray();
+                return _DownloadLines[url.ToUpperInvariant()].ToArray();
             });
 
             _SavedLines = new Dictionary<string,List<string>>();
             _Provider.Setup(p => p.WriteLines(It.IsAny<string>(), It.IsAny<string[]>())).Callback((string fileName, string[] lines) => {
-                var key = fileName.ToUpper();
+                var key = fileName.ToUpperInvariant();
                 var value = new List<string>(lines);
                 _SavedLines.Add(key, value);
             });
 
             _DownloadedCompressedFiles = new Dictionary<string,string>();
             _Provider.Setup(r => r.DownloadAndDecompressFile(It.IsAny<string>(), It.IsAny<string>())).Callback((string url, string fileName) => {
-                _DownloadedCompressedFiles.Add(url.ToUpper(), fileName.ToUpper());
+                _DownloadedCompressedFiles.Add(url.ToUpperInvariant(), fileName.ToUpperInvariant());
             });
 
             _MovedFiles = new Dictionary<string,string>();
             _Provider.Setup(r => r.MoveFile(It.IsAny<string>(), It.IsAny<string>())).Callback((string temporaryFileName, string liveFileName) => {
-                _MovedFiles.Add(temporaryFileName.ToUpper(), liveFileName.ToUpper());
+                _MovedFiles.Add(temporaryFileName.ToUpperInvariant(), liveFileName.ToUpperInvariant());
             });
         }
 
@@ -146,8 +146,8 @@ namespace Test.VirtualRadar.Database
 
         private void AssertLinesDownloaded(string url, string tempFileName, string finalFileName)
         {
-            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpper() == url)), Times.Once());
-            _Provider.Verify(p => p.WriteLines(It.Is<string>(f => f.ToUpper() == tempFileName), It.IsAny<string[]>()), Times.Once());
+            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpperInvariant() == url)), Times.Once());
+            _Provider.Verify(p => p.WriteLines(It.Is<string>(f => f.ToUpperInvariant() == tempFileName), It.IsAny<string[]>()), Times.Once());
 
             List<string> downloadedLines;
             if(!_DownloadLines.TryGetValue(url, out downloadedLines)) downloadedLines = new List<string>();
@@ -179,7 +179,7 @@ namespace Test.VirtualRadar.Database
         {
             _FileExists[StateFileName] = false;
             Assert.AreEqual(true, _Implementation.DataIsOld());
-            _Provider.Verify(p => p.FileExists(It.Is<string>(f => f.ToUpper() == StateFileName)), Times.Once());
+            _Provider.Verify(p => p.FileExists(It.Is<string>(f => f.ToUpperInvariant() == StateFileName)), Times.Once());
             _Provider.Verify(p => p.DownloadLines(It.IsAny<string>()), Times.Never());
         }
 
@@ -187,7 +187,7 @@ namespace Test.VirtualRadar.Database
         public void StandingDataUpdater_DataIsOld_Downloads_Current_State_File()
         {
             _Implementation.DataIsOld();
-            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpper() == StateFileUrl)), Times.Once());
+            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpperInvariant() == StateFileUrl)), Times.Once());
         }
 
         [TestMethod]
@@ -214,7 +214,7 @@ namespace Test.VirtualRadar.Database
         {
             SetupValidStateFileDownload();
             _Implementation.Update();
-            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpper() == StateFileUrl)), Times.Once());
+            _Provider.Verify(p => p.DownloadLines(It.Is<string>(u => u.ToUpperInvariant() == StateFileUrl)), Times.Once());
         }
 
         [TestMethod]
@@ -238,7 +238,7 @@ namespace Test.VirtualRadar.Database
 
             _Implementation.Update();
 
-            _Provider.Verify(p => p.WriteLines(It.Is<string>(f => f.ToUpper() == StateTempFileName), It.IsAny<string[]>()), Times.Never());
+            _Provider.Verify(p => p.WriteLines(It.Is<string>(f => f.ToUpperInvariant() == StateTempFileName), It.IsAny<string[]>()), Times.Never());
         }
         #endregion
 

--- a/Test/Test.VirtualRadar.Interface/FilterStringTests.cs
+++ b/Test/Test.VirtualRadar.Interface/FilterStringTests.cs
@@ -41,15 +41,15 @@ namespace Test.VirtualRadar.Interface
             var filter = new FilterString();
 
             filter.Value = null;
-            filter.ToUpper();
+            filter.ToUpperInvariant();
             Assert.IsNull(filter.Value);
 
             filter.Value = "";
-            filter.ToUpper();
+            filter.ToUpperInvariant();
             Assert.AreEqual("", filter.Value);
 
             filter.Value = "Abc";
-            filter.ToUpper();
+            filter.ToUpperInvariant();
             Assert.AreEqual("ABC", filter.Value);
         }
 
@@ -77,8 +77,8 @@ namespace Test.VirtualRadar.Interface
                                         if(reverseCondition) expectedResult = !expectedResult;
                                     }
                                 } else {
-                                    var ucaseValue = (value ?? "").ToUpper();
-                                    var ucaseTestValue = (testValue ?? "").ToUpper();
+                                    var ucaseValue = (value ?? "").ToUpperInvariant();
+                                    var ucaseTestValue = (testValue ?? "").ToUpperInvariant();
                                     switch(condition) {
                                         case FilterCondition.Contains:      expectedResult = ucaseTestValue.Contains(ucaseValue); break;
                                         case FilterCondition.EndsWith:      expectedResult = ucaseTestValue.EndsWith(ucaseValue); break;
@@ -132,8 +132,8 @@ namespace Test.VirtualRadar.Interface
                                         if(reverseCondition) expectedResult = !expectedResult;
                                     }
                                 } else {
-                                    var ucaseValue = (value ?? "").ToUpper();
-                                    var ucaseTestValue = (testValue ?? new string[0]).Select(r => (r ?? "").ToUpper()).ToArray();
+                                    var ucaseValue = (value ?? "").ToUpperInvariant();
+                                    var ucaseTestValue = (testValue ?? new string[0]).Select(r => (r ?? "").ToUpperInvariant()).ToArray();
                                     switch(condition) {
                                         case FilterCondition.Contains:      expectedResult = ucaseTestValue.Any(r => r.Contains(ucaseValue)); break;
                                         case FilterCondition.EndsWith:      expectedResult = ucaseTestValue.Any(r => r.EndsWith(ucaseValue)); break;

--- a/Test/Test.VirtualRadar.Interface/WebServer/MimeTypeTests.cs
+++ b/Test/Test.VirtualRadar.Interface/WebServer/MimeTypeTests.cs
@@ -90,8 +90,8 @@ namespace Test.VirtualRadar.Interface.WebServer
             var mimeType = worksheet.String("MimeType");
             var extension = String.Format(".{0}", worksheet.String("Extension"));
 
-            Assert.AreEqual(mimeType, MimeType.GetForExtension(extension.ToLower()), extension.ToLower());
-            Assert.AreEqual(mimeType, MimeType.GetForExtension(extension.ToUpper()), extension.ToUpper());
+            Assert.AreEqual(mimeType, MimeType.GetForExtension(extension.ToLowerInvariant()), extension.ToLowerInvariant());
+            Assert.AreEqual(mimeType, MimeType.GetForExtension(extension.ToUpperInvariant()), extension.ToUpperInvariant());
         }
 
         [TestMethod]
@@ -108,11 +108,10 @@ namespace Test.VirtualRadar.Interface.WebServer
         public void MimeType_GetKnownExtensions_Returns_Reasonable_List()
         {
             var worksheet = new ExcelWorksheetData(TestContext);
-            var mimeType = worksheet.String("MimeType");
             var extension = worksheet.String("Extension");
 
             var extensions = MimeType.GetKnownExtensions();
-            Assert.IsTrue(extensions.Contains(extension.ToLower()));
+            Assert.IsTrue(extensions.Contains(extension, StringComparer.InvariantCultureIgnoreCase));
         }
 
         [TestMethod]

--- a/Test/Test.VirtualRadar.Library/BaseStation/RawMessageTranslatorTests.cs
+++ b/Test/Test.VirtualRadar.Library/BaseStation/RawMessageTranslatorTests.cs
@@ -475,7 +475,7 @@ namespace Test.VirtualRadar.Library.BaseStation
             _Translator.AcceptIcaoInNonPIMilliseconds = worksheet.Int("NonPIMs");
 
             IEnumerable<ModeSMessage> messages;
-            switch(worksheet.String("DownlinkFormat").ToUpper()) {
+            switch(worksheet.String("DownlinkFormat").ToUpperInvariant()) {
                 case "HASPI":       messages = CreateModeSMessagesWithPIField(); break;
                 case "NOPI":        messages = CreateModeSMessagesWithNoPIField(); break;
                 default:            throw new NotImplementedException();

--- a/Test/Test.VirtualRadar.Library/DirectoryCacheTests.cs
+++ b/Test/Test.VirtualRadar.Library/DirectoryCacheTests.cs
@@ -82,7 +82,7 @@ namespace Test.VirtualRadar.Library
             _Provider = new Mock<IDirectoryCacheProvider>() { DefaultValue = DefaultValue.Mock }.SetupAllProperties();
             _Provider.Setup(p => p.FolderExists(It.IsAny<string>())).Returns((string folder) => {
                 if(folder != null && folder.EndsWith(@"\")) folder = folder.Substring(0, folder.Length - 1);
-                return _Folders.Contains(folder.ToLower());
+                return _Folders.Contains(folder.ToLowerInvariant());
             });
             _Provider.Setup(p => p.GetSubFoldersInFolder(It.IsAny<string>())).Returns((string folder) => {
                 if(folder != null && !folder.EndsWith(@"\")) folder += '\\';
@@ -96,12 +96,12 @@ namespace Test.VirtualRadar.Library
             _Provider.Setup(p => p.GetFilesInFolder(It.IsAny<string>())).Returns((string folder) => {
                 List<TestFileInfo> files;
                 if(folder != null && folder.EndsWith(@"\")) folder = folder.Substring(0, folder.Length - 1);
-                _Files.TryGetValue(folder.ToLower(), out files);
+                _Files.TryGetValue(folder.ToLowerInvariant(), out files);
                 return (IEnumerable<TestFileInfo>)files ?? new TestFileInfo[0];
             });
             _Provider.Setup(p => p.GetFileInfo(It.IsAny<string>())).Returns((string fullPath) => {
                 TestFileInfo result = null;
-                var folder = (Path.GetDirectoryName(fullPath) ?? "").ToLower();
+                var folder = (Path.GetDirectoryName(fullPath) ?? "").ToLowerInvariant();
                 var fileName = Path.GetFileName(fullPath);
                 List<TestFileInfo> files;
                 if(_Files.TryGetValue(folder, out files)) result = files.FirstOrDefault(r => r.Name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
@@ -132,7 +132,7 @@ namespace Test.VirtualRadar.Library
         {
             if(!String.IsNullOrEmpty(folder)) {
                 if(folder[folder.Length - 1] == '\\') folder = folder.Substring(0, folder.Length - 1);
-                folder = folder.ToLower();
+                folder = folder.ToLowerInvariant();
 
                 var previousFolder = folder;
                 do {
@@ -150,7 +150,7 @@ namespace Test.VirtualRadar.Library
         private TestFileInfo AddToFiles(string directory, TestFileInfo fileInfo)
         {
             if(!String.IsNullOrEmpty(directory)) {
-                directory = directory.ToLower();
+                directory = directory.ToLowerInvariant();
 
                 AddToFolders(directory);
 
@@ -185,7 +185,7 @@ namespace Test.VirtualRadar.Library
         private void RemoveFromFiles(string fullPath)
         {
             try {
-                var directory = Path.GetDirectoryName(fullPath).ToLower();
+                var directory = Path.GetDirectoryName(fullPath).ToLowerInvariant();
                 var fileName = Path.GetFileName(fullPath);
                 List<TestFileInfo> files;
                 if(_Files.TryGetValue(directory, out files)) {

--- a/Test/Test.VirtualRadar.Library/Listener/FeedManagerTests.cs
+++ b/Test/Test.VirtualRadar.Library/Listener/FeedManagerTests.cs
@@ -711,8 +711,8 @@ namespace Test.VirtualRadar.Library.Listener
         public void FeedManager_GetByName_Is_Case_Insensitive()
         {
             _Manager.Initialise();
-            Assert.AreSame(_CreatedFeeds[0].Object, _Manager.GetByName(_Receiver1.Name.ToLower(), false));
-            Assert.AreSame(_CreatedFeeds[0].Object, _Manager.GetByName(_Receiver1.Name.ToUpper(), false));
+            Assert.AreSame(_CreatedFeeds[0].Object, _Manager.GetByName(_Receiver1.Name.ToLowerInvariant(), false));
+            Assert.AreSame(_CreatedFeeds[0].Object, _Manager.GetByName(_Receiver1.Name.ToUpperInvariant(), false));
         }
 
         [TestMethod]

--- a/Test/Test.VirtualRadar.WebSite/ApiControllers/AircraftControllerTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/ApiControllers/AircraftControllerTests.cs
@@ -40,7 +40,7 @@ namespace Test.VirtualRadar.WebSite.ApiControllers
         private void SetupAirportDataDotCom(string icao, string registration, int maxThumbs, HttpStatusCode statusCode, AirportDataThumbnailsJson response)
         {
             var result = new WebRequestResult<AirportDataThumbnailsJson>(statusCode, response);
-            _AirportDataDotCom.Setup(r => r.GetThumbnails((icao ?? "").ToUpper(), (registration ?? "").ToUpper(), maxThumbs)).Returns(result);
+            _AirportDataDotCom.Setup(r => r.GetThumbnails((icao ?? "").ToUpperInvariant(), (registration ?? "").ToUpperInvariant(), maxThumbs)).Returns(result);
         }
 
         private Mock<IBaseStationAircraftList> SetupAircraftList(int receiverId = 1)

--- a/Test/Test.VirtualRadar.WebSite/ApiControllers/DirectoryEntryControllerTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/ApiControllers/DirectoryEntryControllerTests.cs
@@ -81,7 +81,7 @@ namespace Test.VirtualRadar.WebSite.ApiControllers
         private void SetKey(Guid key, bool ensureUppercase = true)
         {
             var text = key.ToString();
-            text = ensureUppercase ? text.ToUpper() : text.ToLower();
+            text = ensureUppercase ? text.ToUpperInvariant() : text.ToLowerInvariant();
 
             _Configuration.GoogleMapSettings.DirectoryEntryKey = text;
         }
@@ -116,7 +116,7 @@ namespace Test.VirtualRadar.WebSite.ApiControllers
             var key = Guid.NewGuid();
             SetKey(key, ensureUppercase: true);
 
-            var json = Get($"/api/3.00/directory-entry/{key.ToString().ToLower()}").Json<DirectoryEntryJson>();
+            var json = Get($"/api/3.00/directory-entry/{key.ToString().ToLowerInvariant()}").Json<DirectoryEntryJson>();
 
             Assert.AreEqual(HttpStatusCode.OK, _Context.ResponseHttpStatusCode);
             Assert.IsNotNull(json);

--- a/Test/Test.VirtualRadar.WebSite/ApiControllers/FeedsControllerTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/ApiControllers/FeedsControllerTests.cs
@@ -1129,7 +1129,7 @@ namespace Test.VirtualRadar.WebSite.ApiControllers
 
                 var queryString = "trfmt=fa";
                 if(upperCase) {
-                    queryString = queryString.ToUpper();
+                    queryString = queryString.ToUpperInvariant();
                 }
 
                 var expected = ExpectedAircraftListJsonBuilderArgs(trailType: TrailType.FullAltitude);
@@ -1148,7 +1148,7 @@ namespace Test.VirtualRadar.WebSite.ApiControllers
 
                 var queryString = "trfmt=fa";
                 if(upperCase) {
-                    queryString = queryString.ToUpper();
+                    queryString = queryString.ToUpperInvariant();
                 }
 
                 var expected = ExpectedAircraftListJsonBuilderArgs(trailType: TrailType.FullAltitude);

--- a/Test/Test.VirtualRadar.WebSite/Middleware/BasicAuthenticationFilterTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/Middleware/BasicAuthenticationFilterTests.cs
@@ -56,7 +56,8 @@ namespace Test.VirtualRadar.WebSite.Middleware
             _AdministratorPaths = new List<string>();
             _AuthenticationConfiguration.Setup(r => r.GetAdministratorPaths()).Returns(() => _AdministratorPaths.ToArray());
             _AuthenticationConfiguration.Setup(r => r.IsAdministratorPath(It.IsAny<string>())).Returns((string pathAndFile) => {
-                return _AdministratorPaths.Any(r => (pathAndFile ?? "").StartsWith(r, StringComparison.InvariantCultureIgnoreCase));
+                var normalised = (pathAndFile ?? "");
+                return _AdministratorPaths.Any(r => normalised.StartsWith(r, StringComparison.InvariantCultureIgnoreCase));
             });
 
             _Filter = Factory.Resolve<IBasicAuthenticationFilter>();

--- a/Test/Test.VirtualRadar.WebSite/Middleware/BasicAuthenticationFilterTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/Middleware/BasicAuthenticationFilterTests.cs
@@ -56,8 +56,7 @@ namespace Test.VirtualRadar.WebSite.Middleware
             _AdministratorPaths = new List<string>();
             _AuthenticationConfiguration.Setup(r => r.GetAdministratorPaths()).Returns(() => _AdministratorPaths.ToArray());
             _AuthenticationConfiguration.Setup(r => r.IsAdministratorPath(It.IsAny<string>())).Returns((string pathAndFile) => {
-                var normalised = (pathAndFile ?? "").ToLower();
-                return _AdministratorPaths.Any(r => normalised.StartsWith(r));
+                return _AdministratorPaths.Any(r => (pathAndFile ?? "").StartsWith(r, StringComparison.InvariantCultureIgnoreCase));
             });
 
             _Filter = Factory.Resolve<IBasicAuthenticationFilter>();
@@ -98,7 +97,7 @@ namespace Test.VirtualRadar.WebSite.Middleware
 
         private void SetAdministratorPath(string pathFromRoot)
         {
-            pathFromRoot = (pathFromRoot ?? "").Trim().ToLower();
+            pathFromRoot = (pathFromRoot ?? "").Trim().ToLowerInvariant();
             if(!pathFromRoot.StartsWith("/")) pathFromRoot = String.Format("/{0}", pathFromRoot);
             if(!pathFromRoot.EndsWith("/")) pathFromRoot = String.Format("{0}/", pathFromRoot);
 

--- a/Test/Test.VirtualRadar.WebSite/Middleware/ImageServerTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/Middleware/ImageServerTests.cs
@@ -99,16 +99,12 @@ namespace Test.VirtualRadar.WebSite.Middleware
         {
             var fullPath = Path.Combine(folder, fileName);
 
-            ImageFormat imageFormat = null;
-            var extension = Path.GetExtension(fileName);
-            if(extension.Equals(".bmp", StringComparison.InvariantCultureIgnoreCase)) {
-                imageFormat = ImageFormat.Bmp;
-            }
-            else if (extension.Equals(".png", StringComparison.InvariantCultureIgnoreCase)) {
-                imageFormat = ImageFormat.Png;
-            }
-            else {
-                throw new NotImplementedException();
+            ImageFormat imageFormat;
+            var extension = Path.GetExtension(fileName).ToLowerInvariant();
+            switch(extension) {
+                case ".bmp": imageFormat = ImageFormat.Bmp; break;
+                case ".png": imageFormat = ImageFormat.Png; break;
+                default:     throw new NotImplementedException();
             }
 
             using(var stream = new MemoryStream()) {

--- a/Test/Test.VirtualRadar.WebSite/Middleware/ImageServerTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/Middleware/ImageServerTests.cs
@@ -99,11 +99,16 @@ namespace Test.VirtualRadar.WebSite.Middleware
         {
             var fullPath = Path.Combine(folder, fileName);
 
-            var imageFormat = ImageFormat.Bmp;
-            switch(Path.GetExtension(fileName).ToLower()) {
-                case ".bmp":    break;
-                case ".png":    imageFormat = ImageFormat.Png; break;
-                default:        throw new NotImplementedException();
+            ImageFormat imageFormat = null;
+            var extension = Path.GetExtension(fileName);
+            if(extension.Equals(".bmp", StringComparison.InvariantCultureIgnoreCase)) {
+                imageFormat = ImageFormat.Bmp;
+            }
+            else if (extension.Equals(".png", StringComparison.InvariantCultureIgnoreCase)) {
+                imageFormat = ImageFormat.Png;
+            }
+            else {
+                throw new NotImplementedException();
             }
 
             using(var stream = new MemoryStream()) {

--- a/Test/Test.VirtualRadar.WebSite/MiddlewareConfiguration/BundlerConfigurationTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/MiddlewareConfiguration/BundlerConfigurationTests.cs
@@ -190,9 +190,9 @@ namespace Test.VirtualRadar.WebSite.MiddlewareConfiguration
             _HtmlEnv.RequestPath = "/index.html";
             _Config.RegisterJavascriptBundle(_HtmlEnv.Environment, 0, new List<string>() { "1" });
 
-            _BndlEnv.RequestPath = "/index-0-bundle.js".ToUpper();
+            _BndlEnv.RequestPath = "/index-0-bundle.js".ToUpperInvariant();
             var bundled1 = _Config.GetJavascriptBundle(_BndlEnv.Environment);
-            _BndlEnv.RequestPath = "/index-0-bundle.js".ToLower();
+            _BndlEnv.RequestPath = "/index-0-bundle.js".ToLowerInvariant();
             var bundled2 = _Config.GetJavascriptBundle(_BndlEnv.Environment);
 
             Assert.IsNotNull(bundled1);

--- a/Test/Test.VirtualRadar.WebSite/MiddlewareConfiguration/FileSystemServerConfigurationTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/MiddlewareConfiguration/FileSystemServerConfigurationTests.cs
@@ -242,7 +242,7 @@ namespace Test.VirtualRadar.WebSite.MiddlewareConfiguration
 
                 var folders = _Configuration.GetSiteRootFolders();
                 Assert.AreEqual(2, folders.Count);
-                var abcIsFirst = folders[0].ToLower().TrimEnd('\\', '/') == abcFolder.ToLower();
+                var abcIsFirst = folders[0].TrimEnd('\\', '/').Equals(abcFolder, StringComparison.InvariantCultureIgnoreCase);
 
                 Assert.AreEqual(expectAbcFirst, abcIsFirst);
                 _Configuration.RemoveSiteRoot(abcSiteRoot);

--- a/Test/Test.VirtualRadar.WebSite/TestImages.tt
+++ b/Test/Test.VirtualRadar.WebSite/TestImages.tt
@@ -63,7 +63,7 @@ var path = Path.GetDirectoryName(project.FullName);
 path = Path.Combine(path, "TestImages");
 var first = true;
 foreach(var fileName in Directory.GetFiles(path)) {
-    var extension = (Path.GetExtension(fileName) ?? "").ToLower();
+    var extension = (Path.GetExtension(fileName) ?? "").ToLowerInvariant();
     if(extension != ".png" && extension != ".ico" && extension != ".jpg" && extension != ".bmp") continue;
 
     var imageFileName = String.Format("../TestImages/{0}", Path.GetFileName(fileName));

--- a/Test/Test.VirtualRadar.WebSite/WebSiteStringsManipulatorTests.cs
+++ b/Test/Test.VirtualRadar.WebSite/WebSiteStringsManipulatorTests.cs
@@ -65,7 +65,7 @@ namespace Test.VirtualRadar.WebSite
 
         private string GetWebsiteStringLanguage(string fileName)
         {
-            return Regex.Match(fileName, @"strings\.(?<lang>.*)\.js", RegexOptions.IgnoreCase).Groups["lang"].Value?.ToLower();
+            return Regex.Match(fileName, @"strings\.(?<lang>.*)\.js", RegexOptions.IgnoreCase).Groups["lang"].Value?.ToLowerInvariant();
         }
 
         [TestMethod]

--- a/ThirdParty/TypeLite.Net35/DocAppender.cs
+++ b/ThirdParty/TypeLite.Net35/DocAppender.cs
@@ -48,7 +48,7 @@ namespace TypeLite.Net4 {
                 return null;
             }
 
-            var key = xmlPath.ToLower();
+            var key = xmlPath.ToLowerInvariant();
             XmlDocumentationProvider provider;
             if (_providers.TryGetValue(key, out provider) == false) {
                 provider = new XmlDocumentationProvider(xmlPath);

--- a/ThirdParty/TypeLite.Net35/Extensions/SystemTypeKindExtensions.cs
+++ b/ThirdParty/TypeLite.Net35/Extensions/SystemTypeKindExtensions.cs
@@ -20,7 +20,7 @@ namespace TypeLite.Extensions {
 				case SystemTypeKind.Bool: return "boolean";
 			}
 
-			return type.ToString().ToLower();
+			return type.ToString().ToLowerInvariant();
 		}
 	}
 }

--- a/ThirdParty/TypeLite.Net35/TsFiles.cs
+++ b/ThirdParty/TypeLite.Net35/TsFiles.cs
@@ -92,7 +92,7 @@ namespace TypeLite {
         /// <returns></returns>
         private static string convertToIdentifier (this string text){
             string result = text;
-            string firstLetter = text[0].ToString().ToLower();
+            string firstLetter = text[0].ToString().ToLowerInvariant();
             result = firstLetter + text.Substring(1);
             result = result.Replace(".", "");
             return result;

--- a/Utilities/BaseStationImport/OptionsParser.cs
+++ b/Utilities/BaseStationImport/OptionsParser.cs
@@ -36,7 +36,7 @@ namespace BaseStationImport
 
             for(var i = 0;i < args.Length;++i) {
                 var arg = (args[i] ?? "");
-                var normalisedArg = arg.ToLower();
+                var normalisedArg = arg.ToLowerInvariant();
                 var nextArg = GetNextArg(args, i);
 
                 switch(normalisedArg) {
@@ -200,7 +200,7 @@ namespace BaseStationImport
             return String.Join(" | ",
                     Enum.GetNames(typeof(T))
                    .OfType<string>()
-                   .OrderBy(r => r.ToLower())
+                   .OrderBy(r => r, StringComparer.InvariantCultureIgnoreCase)
                    .Where(r => exclude == null || !exclude.Contains((T)Enum.Parse(typeof(T), r)))
             );
         }

--- a/VirtualRadar-Service/CommandLineParser.cs
+++ b/VirtualRadar-Service/CommandLineParser.cs
@@ -33,7 +33,7 @@ namespace VirtualRadar
             args = args ?? new string[] {};
             for(var i = 0;i < args.Length;++i) {
                 var arg = args[i];
-                var normalisedArg = (arg ?? "").ToLower().Trim();
+                var normalisedArg = (arg ?? "").ToLowerInvariant().Trim();
                 var nextArg = i + 1 < args.Length ? args[i + 1] : null;
 
                 switch(normalisedArg) {

--- a/VirtualRadar-Service/Program.cs
+++ b/VirtualRadar-Service/Program.cs
@@ -61,8 +61,8 @@ namespace VirtualRadar
         /// <returns></returns>
         static bool ServiceIsInstalled()
         {
-            var serviceName = ProjectInstaller.ServiceName.ToLower();
-            return ServiceController.GetServices().Any(r => (r.ServiceName ?? "").ToLower() == serviceName);
+            return ServiceController.GetServices().Any(r => (r.ServiceName ?? "")
+                .Equals(ProjectInstaller.ServiceName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>

--- a/VirtualRadar-Service/Service.cs
+++ b/VirtualRadar-Service/Service.cs
@@ -99,7 +99,7 @@ namespace VirtualRadar
             var result = new List<string>();
 
             foreach(var arg in args ?? new string[] {}) {
-                switch(arg.ToLower()) {
+                switch(arg.ToLowerInvariant()) {
                     case "-nogui":
                         // Don't let these get through to the program
                         break;

--- a/VirtualRadar.Database/AircraftOnlineLookupCache/StandaloneAircraftOnlineLookupCache.cs
+++ b/VirtualRadar.Database/AircraftOnlineLookupCache/StandaloneAircraftOnlineLookupCache.cs
@@ -144,7 +144,7 @@ namespace VirtualRadar.Database.AircraftOnlineLookupCache
         /// <returns></returns>
         public Dictionary<string, AircraftOnlineLookupDetail> LoadMany(IEnumerable<string> icaos, IDictionary<string, BaseStationAircraft> baseStationAircraft)
         {
-            var filteredIcaos = icaos.Where(r => !String.IsNullOrEmpty(r)).Select(r => r.ToUpper().Trim()).Distinct().ToArray();
+            var filteredIcaos = icaos.Where(r => !String.IsNullOrEmpty(r)).Select(r => r.ToUpperInvariant().Trim()).Distinct().ToArray();
 
             var details = new List<AircraftOnlineLookupDetail>();
             lock(_SyncLock) {
@@ -161,7 +161,7 @@ namespace VirtualRadar.Database.AircraftOnlineLookupCache
             }
 
             var result = details.ToDictionary(r => r.Icao, r => r);
-            foreach(var missingIcao in filteredIcaos.Except(details.Select(r => r.Icao.ToUpper()))) {
+            foreach(var missingIcao in filteredIcaos.Except(details.Select(r => r.Icao.ToUpperInvariant()))) {
                 result.Add(missingIcao, null);
             }
 

--- a/VirtualRadar.Database/BaseStation/Database.cs
+++ b/VirtualRadar.Database/BaseStation/Database.cs
@@ -1480,10 +1480,10 @@ namespace VirtualRadar.Database.BaseStation
         /// <param name="criteria"></param>
         public static void NormaliseCriteria(SearchBaseStationCriteria criteria)
         {
-            if(criteria.Callsign != null)       criteria.Callsign.ToUpper();
-            if(criteria.Icao != null)           criteria.Icao.ToUpper();
-            if(criteria.Registration != null)   criteria.Registration.ToUpper();
-            if(criteria.Type != null)           criteria.Type.ToUpper();
+            if(criteria.Callsign != null)       criteria.Callsign.ToUpperInvariant();
+            if(criteria.Icao != null)           criteria.Icao.ToUpperInvariant();
+            if(criteria.Registration != null)   criteria.Registration.ToUpperInvariant();
+            if(criteria.Type != null)           criteria.Type.ToUpperInvariant();
         }
 
         /// <summary>

--- a/VirtualRadar.Database/BaseStation/ParameterBuilder.cs
+++ b/VirtualRadar.Database/BaseStation/ParameterBuilder.cs
@@ -244,7 +244,7 @@ namespace VirtualRadar.Database.BaseStation
         /// <returns></returns>
         public static string NormaliseAircraftIcao(string icao)
         {
-            return (icao ?? "").ToUpper();
+            return (icao ?? "").ToUpperInvariant();
         }
     }
 }

--- a/VirtualRadar.Database/StandingData/CallsignRouteFetcher.cs
+++ b/VirtualRadar.Database/StandingData/CallsignRouteFetcher.cs
@@ -35,9 +35,9 @@ namespace VirtualRadar.Database.StandingData
 
             public Key(IAircraft aircraft)
             {
-                Icao24 = aircraft.Icao24?.ToUpper();
-                Callsign = aircraft.Callsign?.ToUpper();
-                OperatorIcao = aircraft.OperatorIcao?.ToUpper();
+                Icao24 = aircraft.Icao24?.ToUpperInvariant();
+                Callsign = aircraft.Callsign?.ToUpperInvariant();
+                OperatorIcao = aircraft.OperatorIcao?.ToUpperInvariant();
             }
 
             public override string ToString()

--- a/VirtualRadar.Database/StandingData/StandingDataManager.cs
+++ b/VirtualRadar.Database/StandingData/StandingDataManager.cs
@@ -320,8 +320,8 @@ namespace VirtualRadar.Database.StandingData
                                     continue;
                                 }
 
-                                var isMilitary = mil.ToUpper() == "MIL";
-                                if(!isMilitary && mil.ToUpper() != "CIV") {
+                                var isMilitary = mil.Equals("MIL", StringComparison.InvariantCultureIgnoreCase);
+                                if(!isMilitary && mil.Equals("CIV", StringComparison.InvariantCultureIgnoreCase)) {
                                     log.WriteLine("Invalid military/civilian designator '{0}' - must be one of 'mil' or 'civ' at line {1} of local codeblock override", mil, lineNumber);
                                     continue;
                                 }

--- a/VirtualRadar.Interface/Callsign.cs
+++ b/VirtualRadar.Interface/Callsign.cs
@@ -97,7 +97,7 @@ namespace VirtualRadar.Interface
         /// <param name="callsign"></param>
         public Callsign(string callsign)
         {
-            OriginalCallsign = callsign?.ToUpper().Trim();
+            OriginalCallsign = callsign?.ToUpperInvariant().Trim();
 
             if(!String.IsNullOrEmpty(callsign)) {
                 var match = CallsignRegex.Match(callsign);

--- a/VirtualRadar.Interface/FilterString.cs
+++ b/VirtualRadar.Interface/FilterString.cs
@@ -45,9 +45,9 @@ namespace VirtualRadar.Interface
         /// <summary>
         /// Converts the value to upper-case.
         /// </summary>
-        public void ToUpper()
+        public void ToUpperInvariant()
         {
-            if(Value != null) Value = Value.ToUpper();
+            if(Value != null) Value = Value.ToUpperInvariant();
         }
 
         /// <summary>

--- a/VirtualRadar.Interface/Listener/AirnavXRangeAircraftJson.cs
+++ b/VirtualRadar.Interface/Listener/AirnavXRangeAircraftJson.cs
@@ -35,8 +35,8 @@ namespace VirtualRadar.Interface.Listener
         /// </summary>
         [IgnoreDataMember]
         public string Icao24 {
-            get => RawIcao24?.ToUpper();
-            set => RawIcao24 = value?.ToLower();
+            get => RawIcao24?.ToUpperInvariant();
+            set => RawIcao24 = value?.ToLowerInvariant();
         }
 
         /// <summary>

--- a/VirtualRadar.Interface/ProgramLifetime.cs
+++ b/VirtualRadar.Interface/ProgramLifetime.cs
@@ -176,15 +176,15 @@ namespace VirtualRadar.Interface
         {
             if(args != null) {
                 foreach(string arg in args) {
-                    if(arg.ToUpper().StartsWith("-CULTURE:")) {
+                    if(arg.StartsWith("-CULTURE:", StringComparison.InvariantCultureIgnoreCase)) {
                         ForcedCultureInfo = new CultureInfo(arg.Substring(9));
                         Thread.CurrentThread.CurrentUICulture = ForcedCultureInfo;
                         Thread.CurrentThread.CurrentCulture = ForcedCultureInfo;
-                    } else if(arg.ToUpper() == "-DEFAULTFONTS") {
+                    } else if(arg.Equals("-DEFAULTFONTS", StringComparison.InvariantCultureIgnoreCase)) {
                         DisableFontReplacement = true;
-                    } else if(arg.ToUpper() == "-NOGUI") {
+                    } else if(arg.Equals("-NOGUI", StringComparison.InvariantCultureIgnoreCase)) {
                         Headless = true;
-                    } else if(arg.ToUpper().StartsWith("-WORKINGFOLDER:")) {
+                    } else if(arg.StartsWith("-WORKINGFOLDER:", StringComparison.InvariantCultureIgnoreCase)) {
                         AllowMultipleInstances = true;
                     }
                 }

--- a/VirtualRadar.Interface/UriHelper.cs
+++ b/VirtualRadar.Interface/UriHelper.cs
@@ -32,7 +32,7 @@ namespace VirtualRadar.Interface
         {
             pathFromRoot = (pathFromRoot ?? "").Trim();
             if(convertToLowerCase) {
-                pathFromRoot = pathFromRoot.ToLower();
+                pathFromRoot = pathFromRoot.ToLowerInvariant();
             }
 
             if(!pathFromRoot.StartsWith("/")) pathFromRoot = String.Format("/{0}", pathFromRoot);

--- a/VirtualRadar.Interface/WebServer/MimeType.cs
+++ b/VirtualRadar.Interface/WebServer/MimeType.cs
@@ -102,7 +102,7 @@ namespace VirtualRadar.Interface.WebServer
                 if(extension[0] == '.') {
                     extension = extension.Substring(1);
                 }
-                extension = extension.ToLower();
+                extension = extension.ToLowerInvariant();
                 if(!extensionMap.TryGetValue(extension, out result)) {
                     result = "application/octet-stream";
                 }
@@ -139,7 +139,7 @@ namespace VirtualRadar.Interface.WebServer
                         var mimeType = chunks[0];
                         if(mimeType.Contains('/')) {
                             for(var i = 1;i < chunks.Length;++i) {
-                                var extension = chunks[i].ToLower();
+                                var extension = chunks[i].ToLowerInvariant();
                                 if(!extensionMap.ContainsKey(extension)) {
                                     extensionMap.Add(extension, mimeType);
                                 }

--- a/VirtualRadar.Library/AircraftDetailFetcher.cs
+++ b/VirtualRadar.Library/AircraftDetailFetcher.cs
@@ -437,7 +437,7 @@ namespace VirtualRadar.Library
         {
             try {
                 foreach(var onlineAircraft in args.AircraftDetails) {
-                    CallWithinFetchLock(onlineAircraft.Icao.ToUpper(), (string icao24, AircraftDetail detail, bool isFirstFetch, IAircraft aircraft) => {
+                    CallWithinFetchLock(onlineAircraft.Icao.ToUpperInvariant(), (string icao24, AircraftDetail detail, bool isFirstFetch, IAircraft aircraft) => {
                         return ApplyDatabaseRecord(detail, detail.Aircraft, onlineAircraft, aircraft, isFirstFetch);
                     });
                 }
@@ -460,7 +460,7 @@ namespace VirtualRadar.Library
                 var databaseAircraft = args.Value;
 
                 if(databaseAircraft != null && !String.IsNullOrEmpty(databaseAircraft.ModeS)) {
-                    CallWithinFetchLock(databaseAircraft.ModeS.ToUpper(), (string icao24, AircraftDetail detail, bool isFirstFetch, IAircraft aircraft) => {
+                    CallWithinFetchLock(databaseAircraft.ModeS.ToUpperInvariant(), (string icao24, AircraftDetail detail, bool isFirstFetch, IAircraft aircraft) => {
                         return ApplyDatabaseRecord(detail, databaseAircraft, detail.OnlineAircraft, aircraft, isFirstFetch);
                     });
                 }

--- a/VirtualRadar.Library/AircraftOnlineLookup.cs
+++ b/VirtualRadar.Library/AircraftOnlineLookup.cs
@@ -201,7 +201,7 @@ namespace VirtualRadar.Library
 
         private static string NormaliseIcao(string icao)
         {
-            var result = (icao ?? "").Trim().ToUpper();
+            var result = (icao ?? "").Trim().ToUpperInvariant();
             return result;
         }
 

--- a/VirtualRadar.Library/AircraftOnlineLookupManager.cs
+++ b/VirtualRadar.Library/AircraftOnlineLookupManager.cs
@@ -212,7 +212,7 @@ namespace VirtualRadar.Library
         {
             Initialise();
 
-            var uniqueIcaos = icaos.Where(r => r != null && r.Length == 6).Select(r => r.ToUpper()).Distinct().ToArray();
+            var uniqueIcaos = icaos.Where(r => r != null && r.Length == 6).Select(r => r.ToUpperInvariant()).Distinct().ToArray();
             var result = FetchManyAircraftDetailsFromCache(uniqueIcaos, baseStationAircraft);
 
             var refreshIcaos = result.Where(r => RecordNeedsRefresh(r.Value)).Select(r => r.Key).ToArray();

--- a/VirtualRadar.Library/AircraftOnlineLookupProvider.cs
+++ b/VirtualRadar.Library/AircraftOnlineLookupProvider.cs
@@ -148,7 +148,7 @@ namespace VirtualRadar.Library
             if(result) {
                 var aircraftDetails = JsonConvert.DeserializeObject<AircraftOnlineLookupDetail[]>(jsonText);
                 fetchedAircraft.AddRange(aircraftDetails);
-                missingIcaos.AddRange(icaos.Select(r => r.ToUpper()).Except(aircraftDetails.Select(r => r.Icao.ToUpper())));
+                missingIcaos.AddRange(icaos.Select(r => r.ToUpperInvariant()).Except(aircraftDetails.Select(r => r.Icao.ToUpperInvariant())));
             }
 
             return result;

--- a/VirtualRadar.Library/ConnectionLogger.cs
+++ b/VirtualRadar.Library/ConnectionLogger.cs
@@ -160,7 +160,7 @@ namespace VirtualRadar.Library
         /// <returns></returns>
         private static string FormKey(string ipAddress, string userName)
         {
-            userName = (userName ?? "").Trim().ToUpper();
+            userName = (userName ?? "").Trim().ToUpperInvariant();
 
             return String.Format("{0}{1}{2}",
                 ipAddress,

--- a/VirtualRadar.Library/DirectoryCache.cs
+++ b/VirtualRadar.Library/DirectoryCache.cs
@@ -626,7 +626,7 @@ namespace VirtualRadar.Library
                 if(trailingSlash && !hasTrailingSlash)      result += Path.DirectorySeparatorChar;
                 else if(!trailingSlash && hasTrailingSlash) result = result.Substring(0, result.Length - 1);
 
-                result = result.ToUpper();
+                result = result.ToUpperInvariant();
             }
 
             return result;
@@ -639,7 +639,7 @@ namespace VirtualRadar.Library
         /// <returns></returns>
         private static string NormaliseFileName(string fileName)
         {
-            return fileName == null ? null : fileName.ToUpper();
+            return fileName == null ? null : fileName.ToUpperInvariant();
         }
         #endregion
 

--- a/VirtualRadar.Library/ParallelAccessImageFileManager.cs
+++ b/VirtualRadar.Library/ParallelAccessImageFileManager.cs
@@ -216,7 +216,7 @@ namespace VirtualRadar.Library
         /// <returns></returns>
         private string NormaliseWebPath(string path)
         {
-            return (path ?? "").ToUpper();
+            return (path ?? "").ToUpperInvariant();
         }
     }
 }

--- a/VirtualRadar.Library/Presenter/SettingsPresenter.cs
+++ b/VirtualRadar.Library/Presenter/SettingsPresenter.cs
@@ -364,7 +364,7 @@ namespace VirtualRadar.Library.Presenter
                 .OrderBy(r => r.IsDefault && !r.IsCustom ? 0 : 1)
                 .ThenBy(r => !r.IsCustom ? 0 : 1)
                 .ThenBy(r => r.DisplayOrder)
-                .ThenBy(r => (r.Name ?? "").ToLower())
+                .ThenBy(r => (r.Name ?? ""), StringComparer.InvariantCultureIgnoreCase)
                 .Select(r => r.Name)
                 .ToArray();
 
@@ -813,9 +813,9 @@ namespace VirtualRadar.Library.Presenter
         /// <returns></returns>
         private string[] CombinedFeedAndServerNamesUpperCase(object exceptCurrent)
         {
-            var receiverNames = _View.Configuration.Receivers.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpper());
-            var mergedFeedNames = _View.Configuration.MergedFeeds.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpper());
-            var rebroadcastServerNames = _View.Configuration.RebroadcastSettings.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpper());
+            var receiverNames = _View.Configuration.Receivers.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpperInvariant());
+            var mergedFeedNames = _View.Configuration.MergedFeeds.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpperInvariant());
+            var rebroadcastServerNames = _View.Configuration.RebroadcastSettings.Where(r => r != exceptCurrent).Select(r => (r.Name ?? "").ToUpperInvariant());
 
             return receiverNames.Concat(mergedFeedNames).ToArray();
         }
@@ -1080,7 +1080,7 @@ namespace VirtualRadar.Library.Presenter
                 })) {
                     // The name must be unique
                     var names = CombinedFeedAndServerNamesUpperCase(mergedFeed);
-                    ValueIsNotInList(mergedFeed.Name.ToUpper(), names, new Validation(ValidationField.Name, defaults) {
+                    ValueIsNotInList(mergedFeed.Name.ToUpperInvariant(), names, new Validation(ValidationField.Name, defaults) {
                         Message = Strings.FeedAndServerNamesMustBeUnique,
                     });
 
@@ -1342,7 +1342,7 @@ namespace VirtualRadar.Library.Presenter
                 })) {
                     // The name cannot be the same as any other receiver or merged feed name
                     var names = CombinedFeedAndServerNamesUpperCase(receiver);
-                    ValueIsNotInList(receiver.Name.ToUpper(), names, new Validation(ValidationField.Name, defaults) {
+                    ValueIsNotInList(receiver.Name.ToUpperInvariant(), names, new Validation(ValidationField.Name, defaults) {
                         Message = Strings.FeedAndServerNamesMustBeUnique,
                     });
 
@@ -1486,8 +1486,8 @@ namespace VirtualRadar.Library.Presenter
                 if(StringIsNotEmpty(receiverLocation.Name, new Validation(ValidationField.Location, defaults) {
                     Message = Strings.PleaseEnterNameForLocation,
                 })) {
-                    var names = _View.Configuration.ReceiverLocations.Where(r => r != receiverLocation).Select(r => (r.Name ?? "").ToUpper());
-                    ValueIsNotInList(receiverLocation.Name.ToUpper(), names, new Validation(ValidationField.Location, defaults) {
+                    var names = _View.Configuration.ReceiverLocations.Where(r => r != receiverLocation).Select(r => (r.Name ?? "").ToUpperInvariant());
+                    ValueIsNotInList(receiverLocation.Name.ToUpperInvariant(), names, new Validation(ValidationField.Location, defaults) {
                         Message = Strings.PleaseEnterUniqueNameForLocation,
                     });
                 }

--- a/VirtualRadar.Library/Presenter/SplashPresenter.cs
+++ b/VirtualRadar.Library/Presenter/SplashPresenter.cs
@@ -142,7 +142,7 @@ namespace VirtualRadar.Library.Presenter
 
             if(CommandLineArgs != null) {
                 foreach(var arg in CommandLineArgs) {
-                    var caselessArg = arg.ToUpper();
+                    var caselessArg = arg.ToUpperInvariant();
                     if(caselessArg.StartsWith("-CULTURE:"))         continue;
                     else if(caselessArg == "-SHOWCONFIGFOLDER")     continue;
                     else if(caselessArg == "-DEFAULTFONTS")         continue;

--- a/VirtualRadar.Library/Settings/PluginManifestStorage.cs
+++ b/VirtualRadar.Library/Settings/PluginManifestStorage.cs
@@ -57,7 +57,7 @@ namespace VirtualRadar.Library.Settings
             if(fileName == "") throw new InvalidOperationException("Plugin filename must be supplied");
 
             var extension = Path.GetExtension(fileName);
-            if(extension.ToUpper() != ".DLL") throw new InvalidOperationException($"{fileName} is not a DLL");
+            if(!extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase)) throw new InvalidOperationException($"{fileName} is not a DLL");
 
             var manifestFileName = Path.ChangeExtension(fileName, ".xml");
 

--- a/VirtualRadar.Library/Settings/TileServerSettingsManager.cs
+++ b/VirtualRadar.Library/Settings/TileServerSettingsManager.cs
@@ -277,7 +277,8 @@ namespace VirtualRadar.Library.Settings
             var allDefaults = results.Where(r => r.MapProvider == mapProvider && r.IsDefault && !r.IsCustom).ToArray();
             switch(allDefaults.Length) {
                 case 0:
-                    var nominated = results.OrderBy(r => (r.Name ?? "").ToLower()).FirstOrDefault(r => r.MapProvider == mapProvider && !r.IsCustom);
+                    var nominated = results.OrderBy(r => (r.Name ?? ""), StringComparer.InvariantCultureIgnoreCase)
+                        .FirstOrDefault(r => r.MapProvider == mapProvider && !r.IsCustom);
                     if(nominated != null) {
                         nominated.IsDefault = true;
                     }
@@ -285,7 +286,7 @@ namespace VirtualRadar.Library.Settings
                 case 1:
                     break;
                 default:
-                    foreach(var notDefault in allDefaults.OrderBy(r => (r.Name ?? "").ToLower()).Skip(1)) {
+                    foreach(var notDefault in allDefaults.OrderBy(r => (r.Name ?? ""), StringComparer.InvariantCultureIgnoreCase).Skip(1)) {
                         notDefault.IsDefault = false;
                     }
                     break;

--- a/VirtualRadar.Resources/Images.tt
+++ b/VirtualRadar.Resources/Images.tt
@@ -61,7 +61,7 @@ var path = Path.GetDirectoryName(project.FullName);
 path = Path.Combine(path, "Images");
 var first = true;
 foreach(var fileName in Directory.GetFiles(path)) {
-    var extension = (Path.GetExtension(fileName) ?? "").ToLower();
+    var extension = (Path.GetExtension(fileName) ?? "").ToLowerInvariant();
     if(extension != ".png" && extension != ".ico" && extension != ".jpg") continue;
 
     var imageFileName = String.Format("../TestImages/{0}", Path.GetFileName(fileName));

--- a/VirtualRadar.WebServer/Request.cs
+++ b/VirtualRadar.WebServer/Request.cs
@@ -199,7 +199,7 @@ namespace VirtualRadar.WebServer
         private Encoding ParseEncoding(string charsetName)
         {
             var result = Encoding.UTF8;
-            switch(charsetName.ToUpper()) {
+            switch(charsetName.ToUpperInvariant()) {
                 case "US-ASCII":    result = Encoding.ASCII; break;
                 case "UTF-7":       result = Encoding.UTF7; break;
                 case "UTF-16BE":    result = Encoding.BigEndianUnicode; break;

--- a/VirtualRadar.WebServer/Response.cs
+++ b/VirtualRadar.WebServer/Response.cs
@@ -168,7 +168,7 @@ namespace VirtualRadar.WebServer
                 if(_Response.ContentLength64 != 0) throw new InvalidOperationException("You cannot enable compression after you have started writing to the OutputStream");
 
                 if(!IsBadBrowser(request.UserAgent)) {
-                    var acceptEncoding = (request.Headers["Accept-Encoding"] ?? "*").ToLower();
+                    var acceptEncoding = (request.Headers["Accept-Encoding"] ?? "*").ToLowerInvariant();
                     int? gzipQuality = null;
                     int? othersQuality = null;
                     foreach(var encoding in acceptEncoding.Split(',').Select(r => r.Replace(" ",""))) {

--- a/VirtualRadar.WebSite/ApiControllers/AircraftController.cs
+++ b/VirtualRadar.WebSite/ApiControllers/AircraftController.cs
@@ -46,7 +46,7 @@ namespace VirtualRadar.WebSite.ApiControllers
             } else {
                 try {
                     var airportDataDotCom = Factory.Resolve<IAirportDataDotCom>();
-                    var outcome = airportDataDotCom.GetThumbnails((icao ?? "").ToUpper(), (reg ?? "").ToUpper(), numThumbs);
+                    var outcome = airportDataDotCom.GetThumbnails((icao ?? "").ToUpperInvariant(), (reg ?? "").ToUpperInvariant(), numThumbs);
                     if(outcome.Result == null) {
                         result = new AirportDataThumbnailsJson() {
                             Status = (int)outcome.HttpStatusCode,

--- a/VirtualRadar.WebSite/ApiControllers/FeedsController.cs
+++ b/VirtualRadar.WebSite/ApiControllers/FeedsController.cs
@@ -399,7 +399,7 @@ namespace VirtualRadar.WebSite.ApiControllers
             var result = TrailType.None;
 
             if(!String.IsNullOrEmpty(trFmt)) {
-                switch(trFmt.ToUpper()) {
+                switch(trFmt.ToUpperInvariant()) {
                     case "F":   result = TrailType.Full; break;
                     case "FA":  result = TrailType.FullAltitude; break;
                     case "FS":  result = TrailType.FullSpeed; break;
@@ -416,16 +416,16 @@ namespace VirtualRadar.WebSite.ApiControllers
         {
             var query = RequestQueryString;
 
-            var sortBy1 = (query["sortBy1"] ?? "").ToUpper();
+            var sortBy1 = (query["sortBy1"] ?? "").ToUpperInvariant();
             if(sortBy1 == "") {
                 SetDefaultAircraftListSortBy(args);
             } else {
-                var sortOrder1 = (query["sortOrder1"] ?? "").ToUpper();
+                var sortOrder1 = (query["sortOrder1"] ?? "").ToUpperInvariant();
                 args.SortBy.Add(new KeyValuePair<string, bool>(sortBy1, sortOrder1 == "ASC"));
 
-                var sortBy2 = (query["sortBy2"] ?? "").ToUpper();
+                var sortBy2 = (query["sortBy2"] ?? "").ToUpperInvariant();
                 if(sortBy2 != "") {
-                    var sortOrder2 = (query["sortOrder2"] ?? "").ToUpper();
+                    var sortOrder2 = (query["sortOrder2"] ?? "").ToUpperInvariant();
                     args.SortBy.Add(new KeyValuePair<string, bool>(sortBy2, sortOrder2 == "ASC"));
                 }
             }
@@ -442,7 +442,7 @@ namespace VirtualRadar.WebSite.ApiControllers
 
             var query = RequestQueryString;
             foreach(var kvp in query.Where(r => r.Key.Length > 3 && (r.Key[0] == 'f' || r.Key[0] == 'F'))) {
-                var key = kvp.Key.ToUpper();
+                var key = kvp.Key.ToUpperInvariant();
                 var value = kvp.Value;
                 switch(key.Substring(0, 3)) {
                     case "FAI":     result = DecodeStringFilter     ("FAIR",    key, value, result, (f,v) => f.Airport = v); break;

--- a/VirtualRadar.WebSite/ApiControllers/ReportsController.cs
+++ b/VirtualRadar.WebSite/ApiControllers/ReportsController.cs
@@ -91,7 +91,7 @@ namespace VirtualRadar.WebSite.ApiControllers
             var result = typeof(AircraftReportJson);
 
             var reportType = RequestQueryString["rep"];
-            switch((reportType ?? "").ToUpper()) {
+            switch((reportType ?? "").ToUpperInvariant()) {
                 case "DATE":    result = typeof(FlightReportJson); break;
             }
 
@@ -422,7 +422,7 @@ namespace VirtualRadar.WebSite.ApiControllers
             };
 
             foreach(var kvp in RequestQueryString) {
-                var name = (kvp.Key ?? "").ToUpper();
+                var name = (kvp.Key ?? "").ToUpperInvariant();
                 var value = kvp.Value ?? "";
 
                 if(name.StartsWith("CALL-"))        result.Callsign =               DecodeStringFilter(name, value);
@@ -464,7 +464,7 @@ namespace VirtualRadar.WebSite.ApiControllers
         {
             var result = RequestQueryString[key];
             if(toUpperCase) {
-                result = result?.ToUpper();
+                result = result?.ToUpperInvariant();
             }
 
             return result;

--- a/VirtualRadar.WebSite/Middleware/AudioServer.cs
+++ b/VirtualRadar.WebSite/Middleware/AudioServer.cs
@@ -65,7 +65,7 @@ namespace VirtualRadar.WebSite.Middleware
 
             if(result) {
                 var queryString = context.RequestQueryStringDictionary(caseSensitiveKeys: false);
-                switch(queryString["cmd"]?.ToLower()) {
+                switch(queryString["cmd"]?.ToLowerInvariant()) {
                     case "say":
                         var text = queryString["line"];
                         if(text == null) {

--- a/VirtualRadar.WebSite/Middleware/ImageServer.cs
+++ b/VirtualRadar.WebSite/Middleware/ImageServer.cs
@@ -283,9 +283,9 @@ namespace VirtualRadar.WebSite.Middleware
         {
             var requestFileName = context.RequestPathFileName;
             ImageRequest result = new ImageRequest() {
-                ImageName = Path.GetFileNameWithoutExtension(requestFileName).ToUpper(),
+                ImageName = Path.GetFileNameWithoutExtension(requestFileName).ToUpperInvariant(),
             };
-            switch(Path.GetExtension(requestFileName).ToUpper()) {
+            switch(Path.GetExtension(requestFileName).ToUpperInvariant()) {
                 case ".PNG":    result.ImageFormat = ImageFormat.Png; break;
                 case ".GIF":    result.ImageFormat = ImageFormat.Gif; break;
                 case ".BMP":    result.ImageFormat = ImageFormat.Bmp; break;
@@ -302,7 +302,7 @@ namespace VirtualRadar.WebSite.Middleware
         private ImageRequest ParsePathParts(ImageRequest result, OwinContext context)
         {
             foreach(var pathPart in context.RequestPathParts) {
-                var caselessPart = pathPart.ToUpper();
+                var caselessPart = pathPart.ToUpperInvariant();
 
                 if(caselessPart.StartsWith("ALT-")) {
                     result.ShowAltitudeStalk = true;
@@ -390,7 +390,7 @@ namespace VirtualRadar.WebSite.Middleware
         /// <returns></returns>
         private StandardWebSiteImageSize ParseStandardSize(string text)
         {
-            switch(text.ToUpper()) {
+            switch(text.ToUpperInvariant()) {
                 case "DETAIL":          return StandardWebSiteImageSize.PictureDetail;
                 case "FULL":            return StandardWebSiteImageSize.Full;
                 case "LIST":            return StandardWebSiteImageSize.PictureListThumbnail;

--- a/VirtualRadar.WebSite/MiddlewareConfiguration/AccessConfiguration.cs
+++ b/VirtualRadar.WebSite/MiddlewareConfiguration/AccessConfiguration.cs
@@ -63,7 +63,7 @@ namespace VirtualRadar.WebSite.MiddlewareConfiguration
             /// <returns></returns>
             public static string NormalisePath(string path)
             {
-                return (path ?? "").ToLower();
+                return (path ?? "").ToLowerInvariant();
             }
         }
 

--- a/VirtualRadar.WebSite/MiddlewareConfiguration/AuthenticationConfiguration.cs
+++ b/VirtualRadar.WebSite/MiddlewareConfiguration/AuthenticationConfiguration.cs
@@ -92,11 +92,11 @@ namespace VirtualRadar.WebSite.MiddlewareConfiguration
         {
             var result = false;
 
-            pathAndFile = (pathAndFile ?? "").ToLower();
+            pathAndFile = (pathAndFile ?? "");
 
             var administratorPaths = _AdministratorPaths;
             for(var i = 0;i < administratorPaths.Count;++i) {
-                if(pathAndFile.StartsWith(administratorPaths[i])) {
+                if(pathAndFile.StartsWith(administratorPaths[i], StringComparison.InvariantCultureIgnoreCase)) {
                     result = true;
                     break;
                 }

--- a/VirtualRadar.WebSite/MiddlewareConfiguration/FileSystemServerConfiguration.cs
+++ b/VirtualRadar.WebSite/MiddlewareConfiguration/FileSystemServerConfiguration.cs
@@ -290,7 +290,7 @@ namespace VirtualRadar.WebSite.MiddlewareConfiguration
         /// <returns></returns>
         private static string NormaliseRequestPath(string requestPath)
         {
-            return (requestPath ?? "").ToLower().Replace("\\", "/");
+            return (requestPath ?? "").ToLowerInvariant().Replace("\\", "/");
         }
 
         /// <summary>

--- a/VirtualRadar.WebSite/WebSiteStringsManipulator.cs
+++ b/VirtualRadar.WebSite/WebSiteStringsManipulator.cs
@@ -76,7 +76,7 @@ namespace VirtualRadar.WebSite
                         var extension = javaScriptLanguage.Substring(dotIndex);
                         if(String.Equals(".js", extension, StringComparison.OrdinalIgnoreCase) ||
                            extension.StartsWith(".js?", StringComparison.OrdinalIgnoreCase)) {
-                            result = javaScriptLanguage.Substring(0, dotIndex).ToLower();
+                            result = javaScriptLanguage.Substring(0, dotIndex).ToLowerInvariant();
                         }
                     }
                 }

--- a/VirtualRadar.WinForms/AircraftOnlineLookupLogView.cs
+++ b/VirtualRadar.WinForms/AircraftOnlineLookupLogView.cs
@@ -99,7 +99,7 @@ namespace VirtualRadar.WinForms
 
         private string NormaliseIcao(string icao)
         {
-            return (icao ?? "").ToUpper();
+            return (icao ?? "").ToUpperInvariant();
         }
 
         private void RemoveOldEntries(Dictionary<string, AircraftOnlineLookupLogEntry> icaoMap)

--- a/VirtualRadar.WinForms/SettingPage/PageDataSources.cs
+++ b/VirtualRadar.WinForms/SettingPage/PageDataSources.cs
@@ -107,7 +107,7 @@ namespace VirtualRadar.WinForms.SettingPage
                 .OrderBy(r => r.IsDefault && !r.IsCustom ? 0 : 1)
                 .ThenBy(r => !r.IsCustom ? 0 : 1)
                 .ThenBy(r => r.DisplayOrder)
-                .ThenBy(r => (r.Name ?? "").ToLower())
+                .ThenBy(r => (r.Name ?? ""), StringComparer.InvariantCultureIgnoreCase)
                 .Select(r => r.Name)
                 .ToArray();
 

--- a/_PostBuild.ps1
+++ b/_PostBuild.ps1
@@ -17,7 +17,7 @@ if([string]::IsNullOrWhiteSpace($projectName) -or [string]::IsNullOrWhiteSpace($
 }
 
 $pathFromSolution = '';
-if($projectName.ToLower() -eq 'basestationimport') {
+if($projectName.ToLowerInvariant() -eq 'basestationimport') {
     $pathFromSolution = 'Utilities'
 }
 
@@ -263,7 +263,7 @@ function PostBuild-BaseStationImport
 }
 
 # Main switch
-$caselessProject = $projectName.ToLower()
+$caselessProject = $projectName.ToLowerInvariant()
 if($caselessProject -eq 'virtualradar.website') {
     PostBuild-WebSite-Project
 } elseif($caselessProject.StartsWith('plugin.')) {


### PR DESCRIPTION
ToUpper and ToLower functions are locale dependent so they will have different behaviors on different locales and their usage should be avoided.
I've changed the code to use locale invariant comparison string functions and changed the other uses of ToUpper and ToLower to their locale invariant versions.
The Build.bat fix is required to be able to use it with VS2022, I know that paths for VS2022
could be hardcoded instead but removing them altogether is future-proof.
The Build.bat should be ran through the Developer PowerShell that the VS provides instead.